### PR TITLE
Checks bs.active to determine if plugin should start browserSync.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,51 +2,46 @@ var _ = require('lodash');
 var bs = require('browser-sync').create();
 var debug = require('debug')('metalsmith-browser-sync');
 
-var PLUGIN_NAME = 'browser-sync';
 function browserSyncPlugin(options){
     function plugin(files, metalsmith, done) {
-        // first time through remove ourselves, since we will be continously building
-        // and we only need one browser-sync server active
-        metalsmith.plugins.forEach(function(plugin, index){
-            if(plugin._pluginName === PLUGIN_NAME){
-                metalsmith.plugins.splice(index, 1);
-            }
-        });
-        //default options
-        var bsOptions = {
-            server     : "build",
-            files      : ["src/**/*.md", "templates/**/*.hbs"]
-        };
-        _.merge(bsOptions, options, function merger(a, b){
-            //Always use the array given if there is one
-            if(_.isArray(a)){
-                return b;
-            }
-        });
-
-        function rebuild() {
-            if (!bs.paused) {
-                bs.pause();
-
-                metalsmith.build(function(err) {
-                    var buildMessage = err ? err : 'Build successful';
-                    debug(buildMessage);
-
-                    bs.resume();
-                    bs.reload();
-                });
-            }
-        };
-
-        var watched = bsOptions.files;
-        delete bsOptions.files;
-
-        bs.watch(watched, { ignoreInitial: true }).on('all', rebuild);
-        bs.init(bsOptions);
-
+        // Only execute the plugin if browser-sync isn't active.
+        if (!bs.active) {
+            //default options
+            var bsOptions = {
+                server     : "build",
+                files      : ["src/**/*.md", "templates/**/*.hbs"]
+            };
+            _.merge(bsOptions, options, function merger(a, b){
+                //Always use the array given if there is one
+                if(_.isArray(a)){
+                    return b;
+                }
+            });
+    
+            function rebuild() {
+                if (!bs.paused) {
+                    bs.pause();
+    
+                    metalsmith.build(function(err) {
+                        var buildMessage = err ? err : 'Build successful';
+                        debug(buildMessage);
+    
+                        bs.resume();
+                        bs.reload();
+                    });
+                }
+            };
+    
+            var watched = bsOptions.files;
+            delete bsOptions.files;
+    
+            bs.watch(watched, { ignoreInitial: true }).on('all', rebuild);
+            bs.init(bsOptions);
+        }
+        
+        // Always continue the plugin chain.
         done();
     }
-    plugin._pluginName = PLUGIN_NAME;
     return plugin;
 }
 


### PR DESCRIPTION
Attempts to resolve issue #4 by modifying the plugin to only attempt to instantiate browserSync when browserSync is indicating that it's not active.
