### PR TITLE
Add support for BrowserSync callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ var defaultOpts = {
 
 Note: you can pass any options you could normally pass to [BrowserSync](https://github.com/BrowserSync/browser-sync)
 
+### Callback 
+
+You can also pass a callback function, which is called when BrowserSync has completed all setup tasks and is ready to use.
+This is useful when you need to wait for information (for example: urls, port etc) or perform other tasks synchronously.
+
+```js
+var browserSync = require('metalsmith-browser-sync');
+
+metalsmith.use(browserSync({
+                    server : "myBuildDirectory",
+                    files  : ["src/**/*.md", "templates/**/*.hbs"]
+              }, function (err, bs) {
+                  // do some stuff here
+              }));
+```
+
 ## License
 MIT - [view the full license here] (LICENSE)
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,9 @@ gulp.task('test', function (done) {
         .pipe(istanbul.hookRequire())
         .on('finish', function () {
                 gulp.src('test/*.js')
-                    .pipe(jasmine())
+                    .pipe(jasmine({
+                        verbose: true
+                    }))
                     .on('error', errorHandler)
                     .pipe(istanbul.writeReports({
                               dir : './coverage'

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function browserSyncPlugin(options, callback){
         delete bsOptions.files;
 
         bs.watch(watched, { ignoreInitial: true }).on('all', rebuild);
-        bs.init(bsOptions, callback);
+        bs.init(bsOptions, callback || _.noop);
 
         done();
     }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var bs = require('browser-sync').create();
 var debug = require('debug')('metalsmith-browser-sync');
 
 var PLUGIN_NAME = 'browser-sync';
-function browserSyncPlugin(options){
+function browserSyncPlugin(options, callback){
     function plugin(files, metalsmith, done) {
         // first time through remove ourselves, since we will be continously building
         // and we only need one browser-sync server active
@@ -36,13 +36,13 @@ function browserSyncPlugin(options){
                     bs.reload();
                 });
             }
-        };
+        }
 
         var watched = bsOptions.files;
         delete bsOptions.files;
 
         bs.watch(watched, { ignoreInitial: true }).on('all', rebuild);
-        bs.init(bsOptions);
+        bs.init(bsOptions, callback);
 
         done();
     }

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ var Metalsmith      = require('metalsmith');
 var bsCalledWith    = {};
 var bsWatching;
 var bsCalls = 0;
+var bsCallbackInstance = undefined;
 var bsReloadCount = 0;
 var bsPaused = false;
 var rebuild;
@@ -32,9 +33,13 @@ var browserSyncMock = {
                     };
                 },
 
-                init: function(options) {
+                init: function(options, cb) {
                     bsCalls++;
                     bsCalledWith = options;
+
+                    if (cb) {
+                        cb(null, {});
+                    }
                 },
 
                 pause: function() {
@@ -134,6 +139,18 @@ describe('metalsmith-browser-sync', function () {
         });
     });
 
+    describe('callback', function () {
+        it('should return the browserSync instance', function (done) {
+            function assertions () {
+                expect(bsCallbackInstance).toEqual(jasmine.any(Object));
+            }
+
+            build(plugin({}, function (err, bs) {
+                bsCallbackInstance = bs;
+            })).then(assertions).catch(buildErrorHandler).then(done);
+        });
+    });
+
     it('should not effect other plugins', function(done){
         var foo;
         var plugin2 = function(){
@@ -167,6 +184,7 @@ describe('metalsmith-browser-sync', function () {
         var rawPlugin, metalsmithMock;
         beforeEach(function(){
             bsCalls = 0;
+            bsCallbackInstance = undefined;
             bsReloadCount = 0;
             rawPlugin = plugin();
             metalsmithMock = {


### PR DESCRIPTION
[BrowserSync offers a callback option](https://www.browsersync.io/docs/api/#api-init) that is called when the setup is complete.

It includes a reference to the BrowserSync instance, which is useful to have access to for performing other tasks outside metalsmith
